### PR TITLE
Updated trikStudio checker

### DIFF
--- a/epicbox-trik/Dockerfile
+++ b/epicbox-trik/Dockerfile
@@ -12,4 +12,4 @@ RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty mai
 
 ADD trik_checker.tar.gz /
 RUN chown -R root:root /trikStudio-checker
-
+RUN locale-gen ru_RU.UTF-8 && echo "export LANG=ru_RU.UTF-8" >> ~/.bashrc

--- a/epicbox-trik/Dockerfile
+++ b/epicbox-trik/Dockerfile
@@ -7,10 +7,9 @@ RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty mai
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-    libglib2.0-0 libxext6 libgl1-mesa-glx libstdc++6 libqt5core5a libqt5gui5 \
-    unzip \
+    libglib2.0-0 libxext6 libgl1-mesa-glx libstdc++6 unzip libfreetype6 fontconfig libxrender1 \
  && apt-get clean all
 
 ADD trik_checker.tar.gz /
-RUN chown -R root:root /trikStudio-checker \
- && chown sandbox:sandbox /trikStudio-checker/bin
+RUN chown -R root:root /trikStudio-checker
+


### PR DESCRIPTION
- extra Qt libraries are removed
- now directory with checker binaries can be read-only
- no 'cd' commands
- fixed checker.sh
- all files (reports, trajectories and so on) are created in current directory
- fixed behavior of checker when save file is incorrect --- now it properly reports error to stdout and exits with code 1, no "report" file is created
- locale is set to ru_RU.UTF-8 from Dockerfile
- updated some tasks
