### PR TITLE
Upgrade Ruby to 3.2.3

### DIFF
--- a/epicbox-ruby/Dockerfile
+++ b/epicbox-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-alpine3.18
+FROM ruby:3.2.3-alpine3.18
 LABEL maintainer="Stepik Team <team@stepik.org>"
 
 RUN adduser -DH -h /sandbox sandbox

--- a/epicbox-ruby/Dockerfile
+++ b/epicbox-ruby/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.2.2-alpine3.18
-MAINTAINER Stepik Team <team@stepik.org>
+LABEL maintainer="Stepik Team <team@stepik.org>"
 
 RUN adduser -DH -h /sandbox sandbox
 

--- a/epicbox-ruby/Dockerfile
+++ b/epicbox-ruby/Dockerfile
@@ -1,8 +1,13 @@
-FROM ruby:2.5.3-alpine
-MAINTAINER Stepik Team <ab@stepik.org>
+FROM ruby:3.2.2-alpine3.18
+MAINTAINER Stepik Team <team@stepik.org>
 
-RUN adduser -DH -h /sandbox sandbox && \
-    apk add --no-cache --virtual build-dependencies build-base && \
-    apk add --no-cache sqlite-dev && \
-    gem install rspec:3.8.0 sqlite3:1.3.13 sequel:5.15.0 && \
+RUN adduser -DH -h /sandbox sandbox
+
+WORKDIR /sandbox
+
+COPY Gemfile Gemfile.lock ./
+
+RUN apk add --no-cache --virtual build-dependencies build-base sqlite-dev make gcc musl-dev && \
+    bundle config --global frozen 1 && \
+    bundle install && \
     apk del build-dependencies

--- a/epicbox-ruby/Gemfile
+++ b/epicbox-ruby/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rspec", "~> 3.12"
+gem "sqlite3", "~> 1.6"
+gem "sequel", "~> 5.74"

--- a/epicbox-ruby/Gemfile
+++ b/epicbox-ruby/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "rspec", "~> 3.12"
-gem "sqlite3", "~> 1.6"
-gem "sequel", "~> 5.74"
+gem "rspec", "~> 3.13"
+gem "sqlite3", "~> 1.7"
+gem "sequel", "~> 5.78"

--- a/epicbox-ruby/Gemfile.lock
+++ b/epicbox-ruby/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bigdecimal (3.1.4)
+    diff-lcs (1.5.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    sequel (5.74.0)
+      bigdecimal
+    sqlite3 (1.6.8-x86_64-linux)
+
+PLATFORMS
+  x86_64-linux-musl
+
+DEPENDENCIES
+  rspec (~> 3.12)
+  sequel (~> 5.74)
+  sqlite3 (~> 1.6)
+
+BUNDLED WITH
+   2.4.10

--- a/epicbox-ruby/Gemfile.lock
+++ b/epicbox-ruby/Gemfile.lock
@@ -1,32 +1,32 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bigdecimal (3.1.4)
-    diff-lcs (1.5.0)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    bigdecimal (3.1.6)
+    diff-lcs (1.5.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
-    sequel (5.74.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    sequel (5.78.0)
       bigdecimal
-    sqlite3 (1.6.8-x86_64-linux)
+    sqlite3 (1.7.2-x86_64-linux)
 
 PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  rspec (~> 3.12)
-  sequel (~> 5.74)
-  sqlite3 (~> 1.6)
+  rspec (~> 3.13)
+  sequel (~> 5.78)
+  sqlite3 (~> 1.7)
 
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
Upgrade Ruby to 3.2.3 version.

The supported gems have been upgraded to:
rspec 3.13.0
sequel 5.78.0
sqlite3 1.7.2